### PR TITLE
Adding galleryLayout to the state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `galleryLayout` variable to the state. It holds the value of the currently selected gallery layout.
 
 ## [0.0.3] - 2020-01-13
 ### Added

--- a/react/SearchPageContext.ts
+++ b/react/SearchPageContext.ts
@@ -16,17 +16,20 @@ interface State {
   mobileLayout: string
   showContentLoader: boolean
   isFetchingMore: boolean
+  galleryLayout?: string
 }
 
 interface InitialArgs {
   mobileLayout: string
   showContentLoader: boolean
+  defaultGalleryLayout?: string
 }
 
 type ReducerActions =
   | { type: 'SWITCH_LAYOUT'; args: { mobileLayout: string } }
   | { type: 'HIDE_CONTENT_LOADER' }
   | { type: 'SET_FETCHING_MORE'; args: { isFetchingMore: boolean } }
+  | { type: 'SWITCH_GALLERY_LAYOUT'; args: { galleryLayout: string } }
 
 function reducer(state: State, action: ReducerActions): State {
   switch (action.type) {
@@ -38,6 +41,9 @@ function reducer(state: State, action: ReducerActions): State {
     case 'SET_FETCHING_MORE':
       const { isFetchingMore } = action.args
       return { ...state, isFetchingMore }
+    case 'SWITCH_GALLERY_LAYOUT':
+      const { galleryLayout } = action.args
+      return { ...state, galleryLayout }
     default:
       return state
   }
@@ -47,6 +53,7 @@ const useSearchPageStateReducer = (initialState: InitialArgs) => {
   return useReducer(reducer, {
     mobileLayout: initialState.mobileLayout,
     showContentLoader: initialState.showContentLoader,
+    galleryLayout: initialState.defaultGalleryLayout,
     isFetchingMore: false,
   })
 }

--- a/react/SearchPageContext.ts
+++ b/react/SearchPageContext.ts
@@ -4,18 +4,18 @@ const SearchPageContext = createContext({})
 
 const useSearchPage = () => useContext(SearchPageContext)
 
-const SearchPageStateContext = createContext({})
+const SearchPageStateContext = createContext({} as State)
 
 const useSearchPageState = () => useContext(SearchPageStateContext)
 
-const SearchPageStateDispatch = createContext(() => {})
+const SearchPageStateDispatch = createContext((_: ReducerActions) => {})
 
 const useSearchPageStateDispatch = () => useContext(SearchPageStateDispatch)
 
 interface State {
-  mobileLayout: string
-  showContentLoader: boolean
-  isFetchingMore: boolean
+  mobileLayout?: string
+  showContentLoader?: boolean
+  isFetchingMore?: boolean
   galleryLayout?: string
 }
 

--- a/react/package.json
+++ b/react/package.json
@@ -6,7 +6,7 @@
     "eslint-config-vtex-react": "^4.1.0",
     "prettier": "^1.18.2",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "3.7.3"
+    "typescript": "3.9.7"
   },
   "dependencies": {
     "react": "^16.8.3",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1221,10 +1221,10 @@ type-fest@^0.5.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.5.2.tgz#d6ef42a0356c6cd45f49485c3b6281fc148e48a2"
   integrity sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==
 
-typescript@3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 uri-js@^4.2.2:
   version "4.2.2"


### PR DESCRIPTION
#### What problem is this solving?

Adds galleryLayout to the state so it can hold the currently selected value for the Gallery Layouts that are available.

#### How to test it?

[This workspace](https://icarosearch--storecomponents.myvtex.com/apparel---accessories/) actively uses this new variable to hold the selected layout name.

[This workspace](https://icarosearch2--storecomponents.myvtex.com/apparel---accessories/) this workspace can be used to test backwards compatibility.